### PR TITLE
Fix server handling and add automated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Space_Invider
+# Space Invaders
 
 Un mini-jeu inspiré de Space Invaders, réalisé à 100% avec l'aide de l'intelligence artificielle.
 
 ## 🎮 Description
 
-Space_Invider est un jeu d'arcade en 2D dans lequel le joueur contrôle un vaisseau spatial et doit éliminer des vagues d’aliens ennemis. Il a été entièrement généré avec l'aide d'une IA, depuis le code jusqu'aux visuels et à la logique du jeu.
+Space Invaders est un jeu d'arcade en 2D dans lequel le joueur contrôle un vaisseau spatial et doit éliminer des vagues d’aliens ennemis. Il a été entièrement généré avec l'aide d'une IA, depuis le code jusqu'aux visuels et à la logique du jeu.
 
 ## 🚀 Fonctionnalités
 
@@ -24,7 +24,7 @@ Space_Invider est un jeu d'arcade en 2D dans lequel le joueur contrôle un vaiss
 ## 📁 Structure du projet
 
 ```
-Space_Invider-main/
+space-invaders/
 ├── assets/
 │   └── images/
 │       ├── alien_sprite.png
@@ -46,7 +46,7 @@ Space_Invider-main/
 node server.js
 ```
 
-4. Ouvre un navigateur à l'adresse [http://localhost:3000](http://localhost:3000)
+4. Ouvre un navigateur à l'adresse [http://localhost:3000](http://localhost:3000). Tu peux aussi définir la variable d'environnement `PORT` pour utiliser un autre port.
 
 
 ## 🤖 Créé avec l'aide de l'IA

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "space-invaders",
+  "version": "1.0.0",
+  "description": "Space Invaders browser game served with Node.js",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  },
+  "keywords": [
+    "game",
+    "space-invaders",
+    "node"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { once } = require('node:events');
+const server = require('../server');
+
+async function makeRequest(port, path) {
+    return new Promise((resolve, reject) => {
+        const req = http.request(
+            {
+                hostname: '127.0.0.1',
+                port,
+                path,
+                method: 'GET',
+            },
+            (res) => {
+                let data = '';
+                res.setEncoding('utf8');
+                res.on('data', (chunk) => {
+                    data += chunk;
+                });
+                res.on('end', () => {
+                    resolve({
+                        statusCode: res.statusCode,
+                        body: data,
+                        headers: res.headers,
+                    });
+                });
+            }
+        );
+
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+test('HTTP server responses', async (t) => {
+    const serverInstance = server.listen(0);
+    await once(serverInstance, 'listening');
+    const address = serverInstance.address();
+    const port = typeof address === 'string' ? 80 : address.port;
+
+    t.after(() =>
+        new Promise((resolve, reject) => {
+            serverInstance.close((err) => (err ? reject(err) : resolve()));
+        })
+    );
+
+    await t.test('serves the index page', async () => {
+        const response = await makeRequest(port, '/');
+        assert.equal(response.statusCode, 200);
+        assert.match(response.body, /<!DOCTYPE html>/i);
+    });
+
+    await t.test('returns 404 for unknown paths', async () => {
+        const response = await makeRequest(port, '/does-not-exist');
+        assert.equal(response.statusCode, 404);
+        assert.match(response.body, /404/i);
+    });
+});


### PR DESCRIPTION
## Summary
- rename the README references to "Space Invaders" and clarify how to choose the server port
- refactor the static server to default to port 3000, sanitize requested paths, and return an inline 404 page when files are missing
- add a basic Node test suite with npm scripts to verify the homepage and 404 responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d10b2ba090832da4d1029ff0b6dbe0