### PR TITLE
Add alien movement improvements and difficulty helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Space_Invider
+# Space Invaders
 
 Un mini-jeu inspiré de Space Invaders, réalisé à 100% avec l'aide de l'intelligence artificielle.
 
 ## 🎮 Description
 
-Space_Invider est un jeu d'arcade en 2D dans lequel le joueur contrôle un vaisseau spatial et doit éliminer des vagues d’aliens ennemis. Il a été entièrement généré avec l'aide d'une IA, depuis le code jusqu'aux visuels et à la logique du jeu.
+Space Invaders est un jeu d'arcade en 2D dans lequel le joueur contrôle un vaisseau spatial et doit éliminer des vagues d’aliens ennemis. Il a été entièrement généré avec l'aide d'une IA, depuis le code jusqu'aux visuels et à la logique du jeu.
 
 ## 🚀 Fonctionnalités
 
@@ -24,7 +24,7 @@ Space_Invider est un jeu d'arcade en 2D dans lequel le joueur contrôle un vaiss
 ## 📁 Structure du projet
 
 ```
-Space_Invider-main/
+space-invaders/
 ├── assets/
 │   └── images/
 │       ├── alien_sprite.png
@@ -46,7 +46,7 @@ Space_Invider-main/
 node server.js
 ```
 
-4. Ouvre un navigateur à l'adresse [http://localhost:3000](http://localhost:3000)
+4. Ouvre un navigateur à l'adresse [http://localhost:3000](http://localhost:3000). Tu peux aussi définir la variable d'environnement `PORT` pour utiliser un autre port.
 
 
 ## 🤖 Créé avec l'aide de l'IA

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Space Invader</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/phaser/3.55.2/phaser.min.js"></script>
+    <script src="js/gameLogic.js"></script>
     <script src="js/game.js"></script>
     <style>
         body {

--- a/js/gameLogic.js
+++ b/js/gameLogic.js
@@ -1,0 +1,63 @@
+(function (global) {
+    const DEFAULT_CONFIG = {
+        initialVerticalSpeed: 60,
+        initialHorizontalSpeed: 40,
+        initialTimerDelay: 2000,
+        verticalIncrement: 12,
+        horizontalIncrement: 12,
+        delayDecrement: 150,
+        minDelay: 600,
+        maxVerticalSpeed: 220,
+        maxHorizontalSpeed: 180,
+        boundaryPadding: 60,
+    };
+
+    Object.freeze(DEFAULT_CONFIG);
+
+    function resetDifficulty(config = DEFAULT_CONFIG) {
+        return {
+            waveLevel: 1,
+            verticalSpeed: config.initialVerticalSpeed,
+            horizontalSpeed: config.initialHorizontalSpeed,
+            timerDelay: config.initialTimerDelay,
+        };
+    }
+
+    function applyDifficultyProgression(state, config = DEFAULT_CONFIG) {
+        return {
+            waveLevel: state.waveLevel + 1,
+            verticalSpeed: Math.min(state.verticalSpeed + config.verticalIncrement, config.maxVerticalSpeed),
+            horizontalSpeed: Math.min(state.horizontalSpeed + config.horizontalIncrement, config.maxHorizontalSpeed),
+            timerDelay: Math.max(state.timerDelay - config.delayDecrement, config.minDelay),
+        };
+    }
+
+    function willHitHorizontalBounds(positions, direction, speed, width, padding = DEFAULT_CONFIG.boundaryPadding) {
+        if (!Array.isArray(positions) || positions.length === 0) {
+            return false;
+        }
+
+        const minX = padding;
+        const maxX = width - padding;
+
+        return positions.some((x) => {
+            const nextX = x + direction * speed;
+            return nextX <= minX || nextX >= maxX;
+        });
+    }
+
+    const api = {
+        DEFAULT_CONFIG,
+        resetDifficulty,
+        applyDifficultyProgression,
+        willHitHorizontalBounds,
+    };
+
+    if (global) {
+        global.GameLogic = api;
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : typeof self !== 'undefined' ? self : this);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "space-invaders",
+  "version": "1.0.0",
+  "description": "Space Invaders browser game served with Node.js",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  },
+  "keywords": [
+    "game",
+    "space-invaders",
+    "node"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/test/gameLogic.test.js
+++ b/test/gameLogic.test.js
@@ -1,0 +1,56 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    DEFAULT_CONFIG,
+    resetDifficulty,
+    applyDifficultyProgression,
+    willHitHorizontalBounds,
+} = require('../js/gameLogic');
+
+test('difficulty progression increases challenge gradually', () => {
+    const customConfig = {
+        ...DEFAULT_CONFIG,
+        verticalIncrement: 20,
+        horizontalIncrement: 20,
+        delayDecrement: 600,
+        minDelay: 800,
+        maxVerticalSpeed: 120,
+        maxHorizontalSpeed: 70,
+    };
+
+    let state = resetDifficulty(customConfig);
+    assert.equal(state.waveLevel, 1);
+    assert.equal(state.verticalSpeed, customConfig.initialVerticalSpeed);
+    assert.equal(state.horizontalSpeed, customConfig.initialHorizontalSpeed);
+    assert.equal(state.timerDelay, customConfig.initialTimerDelay);
+
+    state = applyDifficultyProgression(state, customConfig);
+    assert.equal(state.waveLevel, 2);
+    assert.equal(state.verticalSpeed, customConfig.initialVerticalSpeed + customConfig.verticalIncrement);
+    assert.equal(state.horizontalSpeed, customConfig.initialHorizontalSpeed + customConfig.horizontalIncrement);
+    assert.equal(state.timerDelay, customConfig.initialTimerDelay - customConfig.delayDecrement);
+
+    state = applyDifficultyProgression(state, customConfig);
+    assert.equal(state.waveLevel, 3);
+    assert.equal(state.verticalSpeed, customConfig.initialVerticalSpeed + customConfig.verticalIncrement * 2);
+    assert.equal(state.horizontalSpeed, customConfig.maxHorizontalSpeed);
+    assert.equal(state.timerDelay, customConfig.minDelay);
+
+    state = applyDifficultyProgression(state, customConfig);
+    assert.equal(state.waveLevel, 4);
+    assert.equal(state.verticalSpeed, customConfig.maxVerticalSpeed);
+    assert.equal(state.horizontalSpeed, customConfig.maxHorizontalSpeed);
+    assert.equal(state.timerDelay, customConfig.minDelay);
+});
+
+test('horizontal bounds detection flags edges correctly', () => {
+    const width = 800;
+    const padding = 60;
+    const positions = [width / 2, width / 2 + 50];
+
+    assert.equal(willHitHorizontalBounds(positions, 1, 10, width, padding), false);
+    assert.equal(willHitHorizontalBounds([width - padding - 5], 1, 10, width, padding), true);
+    assert.equal(willHitHorizontalBounds([padding + 5], -1, 10, width, padding), true);
+    assert.equal(willHitHorizontalBounds([], 1, 10, width, padding), false);
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { once } = require('node:events');
+const server = require('../server');
+
+async function makeRequest(port, path) {
+    return new Promise((resolve, reject) => {
+        const req = http.request(
+            {
+                hostname: '127.0.0.1',
+                port,
+                path,
+                method: 'GET',
+            },
+            (res) => {
+                let data = '';
+                res.setEncoding('utf8');
+                res.on('data', (chunk) => {
+                    data += chunk;
+                });
+                res.on('end', () => {
+                    resolve({
+                        statusCode: res.statusCode,
+                        body: data,
+                        headers: res.headers,
+                    });
+                });
+            }
+        );
+
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+test('HTTP server responses', async (t) => {
+    const serverInstance = server.listen(0);
+    await once(serverInstance, 'listening');
+    const address = serverInstance.address();
+    const port = typeof address === 'string' ? 80 : address.port;
+
+    t.after(() =>
+        new Promise((resolve, reject) => {
+            serverInstance.close((err) => (err ? reject(err) : resolve()));
+        })
+    );
+
+    await t.test('serves the index page', async () => {
+        const response = await makeRequest(port, '/');
+        assert.equal(response.statusCode, 200);
+        assert.match(response.body, /<!DOCTYPE html>/i);
+    });
+
+    await t.test('returns 404 for unknown paths', async () => {
+        const response = await makeRequest(port, '/does-not-exist');
+        assert.equal(response.statusCode, 404);
+        assert.match(response.body, /404/i);
+    });
+});


### PR DESCRIPTION
## Summary
- add a shared game logic helper to drive difficulty scaling and horizontal bounds checks
- update the Phaser scene to reuse alien groups, add horizontal zig-zag, and ramp difficulty between waves
- load the new helper in the HTML entry point and add unit tests covering the progression logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d10b2ba090832da4d1029ff0b6dbe0